### PR TITLE
Change PUT for POST in add-update-comment

### DIFF
--- a/api/v1/routes.json
+++ b/api/v1/routes.json
@@ -922,7 +922,7 @@
     "add-update-comment": {
       "url": "/companies/:company-id/updates/key=:update-key/update-comments-as-company/",
       "doc-url": "https://developer.linkedin.com/documents/commenting-and-liking-company-share",
-      "method": "PUT",
+      "method": "POST",
       "params": {
         "$update-key": null,
         "$company-id": null,


### PR DESCRIPTION
The function add-update-comment is not working because there is a PUT method instead of POST, as it says in the Linkedin API.